### PR TITLE
fix deprecation warnings

### DIFF
--- a/qefientryrebootview.cpp
+++ b/qefientryrebootview.cpp
@@ -91,7 +91,11 @@ void QEFIEntryRebootView::rebootClicked(bool checked)
 #ifdef Q_OS_WIN
             process.startDetached("shutdown", {"/r"});
 #else
+#if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
+            process.startDetached("reboot", {});
+#else
             process.startDetached("reboot");
+#endif
 #endif
         } else {
             // Do nothing

--- a/qefientryview.cpp
+++ b/qefientryview.cpp
@@ -111,7 +111,7 @@ void QEFIEntryView::setCurrentClicked(bool checked)
 {
     // Set BootCurrent
     if (m_selectedItemIndex > 0) {
-        m_order.swap(m_selectedItemIndex, 0);
+        m_order.swapItemsAt(m_selectedItemIndex, 0);
         resetClicked(checked);
     }
     updateButtonState();
@@ -121,7 +121,7 @@ void QEFIEntryView::moveUpClicked(bool checked)
 {
     // Move the current up
     if (m_selectedItemIndex > 0) {
-        m_order.swap(m_selectedItemIndex, m_selectedItemIndex - 1);
+        m_order.swapItemsAt(m_selectedItemIndex, m_selectedItemIndex - 1);
         resetClicked(checked);
     }
     updateButtonState();
@@ -131,7 +131,7 @@ void QEFIEntryView::moveDownClicked(bool checked)
 {
     // Move the current down
     if (m_selectedItemIndex < m_order.size() - 1) {
-        m_order.swap(m_selectedItemIndex, m_selectedItemIndex + 1);
+        m_order.swapItemsAt(m_selectedItemIndex, m_selectedItemIndex + 1);
         resetClicked(checked);
     }
     updateButtonState();


### PR DESCRIPTION
- use `process.startDetached(QString, QStringList)` instead of `process.startDetached(QString)`
  - This is introduced since Qt 5.10, since no Qt minimum version is specified in `CMakeLists`, so added a `QT_VERSION_CHECK` guard
- use `QList<T>::swapItemsAt` instead of `QList<T>::swap`