### PR TITLE
refactor: use QStringLiteral() & arg() to concatenate strings

### DIFF
--- a/.github/workflows/cmake-linux-amd64-appimage.yml
+++ b/.github/workflows/cmake-linux-amd64-appimage.yml
@@ -48,7 +48,7 @@ jobs:
         ./linuxdeploy-x86_64.AppImage --appdir AppDir --plugin qt --output appimage
 
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         # Artifact name
         name: QEFI Entry Manager x86_64 AppImage

--- a/.github/workflows/cmake-windows-x86-x64.yml
+++ b/.github/workflows/cmake-windows-x86-x64.yml
@@ -58,7 +58,7 @@ jobs:
         run: windeployqt.exe --release --no-quick-import ${{github.workspace}}\build\${{env.BUILD_TYPE}}\
 
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v4
         with:
           # Artifact name
           name: QEFI Entry Manager for Windows Qt${{ matrix.qtvers }}

--- a/qefientryview.cpp
+++ b/qefientryview.cpp
@@ -40,8 +40,16 @@ QEFIEntryView::QEFIEntryView(QWidget *parent)
     for (int i = 0; i < m_order.size(); i++) {
         if (m_entryItems.contains(m_order[i])) {
             QEFIEntry &entry = m_entryItems[m_order[i]];
-            m_entries->addItem(QString::asprintf("[%04X] ", entry.id()) + entry.name()
-                + (entry.devicePath().size() > 0 ? "\n" + entry.devicePath() : ""));
+            QString item = QStringLiteral("[%1] %2")
+                .arg(entry.id(), 4, 16, QLatin1Char('0'))
+                .arg(entry.name());
+
+            if (entry.devicePath().size() > 0) {
+                item.append('\n').append(entry.devicePath());
+            }
+
+            m_entries->addItem(item);
+
             // Get the activation state
             QListWidgetItem *currentItem = m_entries->item(i);
             if (currentItem && !entry.isActive()) {
@@ -138,8 +146,15 @@ void QEFIEntryView::resetClicked(bool checked)
     for (int i = 0; i < m_order.size(); i++) {
         if (m_entryItems.contains(m_order[i])) {
             QEFIEntry &entry = m_entryItems[m_order[i]];
-            m_entries->addItem(QString::asprintf("[%04X] ", entry.id()) + entry.name()
-                + (entry.devicePath().size() > 0 ? "\n" + entry.devicePath() : ""));
+            QString item = QStringLiteral("[%1] %2")
+                .arg(entry.id(), 4, 16, QLatin1Char('0'))
+                .arg(entry.name());
+
+            if (entry.devicePath().size() > 0) {
+                item.append('\n').append(entry.devicePath());
+            }
+
+            m_entries->addItem(item);
         }
     }
     updateButtonState();


### PR DESCRIPTION
- Concatenating strings with `QStringLiteral()` & `arg()` provides better code readability.