### PR TITLE
refactor: replace QString::asprintf() with QString::arg()

### DIFF
--- a/helpers.cpp
+++ b/helpers.cpp
@@ -261,7 +261,7 @@ QList<QPair<QString, QString>> convert_device_path_attrs(QEFIDevicePath *dp)
                     QList<quint32> addrs = dpADR->addresses();
                     for (int i = 0; i < addrs.size(); i++) {
                         list << qMakePair<QString, QString>(
-                            QString::asprintf("Address %d:", i + 1),
+                            QStringLiteral("Address %1:").arg(i + 1),
                             QString::number(addrs[i])
                         );
                     }
@@ -389,16 +389,10 @@ QList<QPair<QString, QString>> convert_device_path_attrs(QEFIDevicePath *dp)
                             dynamic_cast<QEFIDevicePathMessageIPv4Addr *>(dp);
                     QEFIIPv4Address local = dpMessage->localIPv4Address();
                     list << qMakePair<QString, QString>("Local IP",
-                        QString::asprintf("%d.%d.%d.%d", local.address[0],
-                                                         local.address[1],
-                                                         local.address[2],
-                                                         local.address[3]));
+                        convert_ipv4_to_string(&local));
                     QEFIIPv4Address remote = dpMessage->remoteIPv4Address();
                     list << qMakePair<QString, QString>("Remote IP",
-                        QString::asprintf("%d.%d.%d.%d", remote.address[0],
-                                                         remote.address[1],
-                                                         remote.address[2],
-                                                         remote.address[3]));
+                        convert_ipv4_to_string(&remote));
                     list << qMakePair<QString, QString>("Local Port",
                         QString::number(dpMessage->localPort()));
                     list << qMakePair<QString, QString>("Remote Port",
@@ -409,16 +403,10 @@ QList<QPair<QString, QString>> convert_device_path_attrs(QEFIDevicePath *dp)
                         dpMessage->staticIPAddress() ? "Yes" : " No");
                     QEFIIPv4Address gw = dpMessage->gateway();
                     list << qMakePair<QString, QString>("Gateway IP",
-                        QString::asprintf("%d.%d.%d.%d", gw.address[0],
-                                                         gw.address[1],
-                                                         gw.address[2],
-                                                         gw.address[3]));
+                        convert_ipv4_to_string(&gw));
                     QEFIIPv4Address netmask = dpMessage->netmask();
                     list << qMakePair<QString, QString>("Netmask",
-                        QString::asprintf("%d.%d.%d.%d", netmask.address[0],
-                                                         netmask.address[1],
-                                                         netmask.address[2],
-                                                         netmask.address[3]));
+                        convert_ipv4_to_string(&netmask));
                 }
                 break;
             case QEFIDevicePathMessageSubType::MSG_IPv6:
@@ -1299,6 +1287,14 @@ QList<QPair<QString, enum QEFIDPEditType>> convert_device_path_types(QEFIDeviceP
         break;
     }
     return list;
+}
+
+QString convert_ipv4_to_string(const QEFIIPv4Address *ipv4) {
+    const auto addr = ipv4->address;
+    return QStringLiteral("%d.%d.%d.%d").arg(addr[0])
+                                        .arg(addr[1])
+                                        .arg(addr[2])
+                                        .arg(addr[3]);
 }
 
 QList<quint8> enum_device_path_subtype(QEFIDevicePathType type)

--- a/helpers.h
+++ b/helpers.h
@@ -20,6 +20,7 @@ enum QEFIDPEditType {
     EditType_UUID
 };
 QList<QPair<QString, enum QEFIDPEditType>> convert_device_path_types(QEFIDevicePath *dp);
+QString convert_ipv4_to_string(const QEFIIPv4Address *ipv4);
 QList<quint8> enum_device_path_subtype(QEFIDevicePathType type);
 
 #endif // HELPERS_H

--- a/qefientrydetailview.cpp
+++ b/qefientrydetailview.cpp
@@ -8,7 +8,7 @@ QEFIEntryDetailBriefView::QEFIEntryDetailBriefView(
     m_briefLayout = new QFormLayout(this);
 
     m_briefLayout->addRow("ID:",
-        new QLabel(QString::asprintf("Boot%04X ", entry.id())));
+        new QLabel(QStringLiteral("Boot%1 ").arg(entry.id(), 4, 16, QLatin1Char('0'))));
     m_briefLayout->addRow("Name:", new QLabel(entry.name()));
 
     QEFILoadOption *loadOption = entry.loadOption();
@@ -62,7 +62,7 @@ QEFIEntryDetailView::QEFIEntryDetailView(QEFIEntry &entry, QWidget *parent)
         // Add a tab to display each DP
         for (int i = 0; i < dpList.size(); i++) {
             m_tab->addTab(new QEFIEntryDPDetailView(dpList[i].get(), m_tab),
-                QString::asprintf("DP %d", i + 1));
+                QStringLiteral("DP %1").arg(i + 1));
         }
     }
     m_topLevelLayout->addWidget(m_tab);

--- a/qefientrydpdetailview.cpp
+++ b/qefientrydpdetailview.cpp
@@ -12,8 +12,9 @@ QEFIEntryDPDetailView::QEFIEntryDPDetailView(QEFIDevicePath *dp, QWidget *parent
         convert_device_path_subtype_to_name(dp->type(), dp->subType()))
     );
     m_topLevelLayout->addRow(QStringLiteral(""),
-        new QLabel(QString::asprintf("%02X %02X",
-            dp->type(), dp->subType()))
+        new QLabel(QStringLiteral("%1 %1")
+	    .arg(dp->type(), 2, 16, QLatin1Char('0'))
+	    .arg(dp->subType(), 2, 16, QLatin1Char('0')))
     );
     // Parse device path and add more properties
     QList<QPair<QString, QString>> attrs = convert_device_path_attrs(dp);

--- a/qefientrystaticlist.cpp
+++ b/qefientrystaticlist.cpp
@@ -85,7 +85,7 @@ void QEFIEntryStaticList::load()
     m_entries.clear();
     for (int i = 0; i < data.size() / 2; i++, order_num++) {
         quint16 order_id = qFromLittleEndian<quint16>(*order_num);
-        QString name = QString::asprintf("Boot%04X", order_id);
+        QString name = QStringLiteral("Boot%1").arg(order_id, 4, 16, QLatin1Char('0'));
         QByteArray boot_data = qefi_get_variable(g_efiUuid,
                                                  name);
         QEFILoadOption *loadOption = new QEFILoadOption(boot_data);
@@ -147,7 +147,7 @@ bool QEFIEntryStaticList::setBootVisibility(
             if (visible) attribute |= 0x00000001;
             else attribute &= 0xFFFFFFFE;
 
-            QString name = QString::asprintf("Boot%04X", bootID);
+            QString name = QStringLiteral("Boot%1").arg(bootID, 4, 16, QLatin1Char('0'));
             bootData[3] = (attribute >> 24);
             bootData[2] = ((attribute >> 16) & 0xFF);
             bootData[1] = ((attribute >> 8) & 0xFF);
@@ -191,7 +191,7 @@ bool QEFIEntryStaticList::updateBootEntry(const quint16 bootID, const QByteArray
     m_loadOptions.insert(bootID, loadOption);
 
     // Write the data
-    QString name = QString::asprintf("Boot%04X", bootID);
+    QString name = QStringLiteral("Boot%1").arg(bootID, 4, 16, QLatin1Char('0'));
     qefi_set_variable(g_efiUuid,
                       name, data);
 

--- a/qefientryview.cpp
+++ b/qefientryview.cpp
@@ -351,7 +351,7 @@ void QEFIEntryView::exportClicked(bool checked)
         exportFile.commit();
 #else
         QFileDialog::saveFileContent(data,
-            QString::asprintf("Boot%04X.bin", m_order[m_selectedItemIndex]));
+            QStringLiteral("Boot%1.bin").arg(m_order[m_selectedItemIndex], 4, 16, QLatin1Char('0')));
 #endif
     }
 }
@@ -362,7 +362,8 @@ void QEFIEntryView::contextMenuEvent(QContextMenuEvent *event)
     if (m_selectedItemIndex >= 0 || m_selectedItemIndex < m_order.size()) {
         QListWidgetItem *currentItem = m_entries->itemAt(event->pos());
         if (currentItem != nullptr) {
-            menu.addSection(QString::asprintf("Boot%04X", m_order[m_selectedItemIndex]));
+            menu.addSection(QStringLiteral("Boot%1").arg(m_order[m_selectedItemIndex],
+							  4, 16, QLatin1Char('0')));
 
             QEFIEntry &entry = m_entryItems[m_order[m_selectedItemIndex]];
             connect(menu.addAction(entry.isActive() ?


### PR DESCRIPTION
- According to [Qt Documentation](https://doc.qt.io/qt-6/qstring.html#asprintf), 
> Warning: We do not recommend using QString::asprintf() in new Qt code. Instead, consider using [QTextStream](https://doc.qt.io/qt-6/qtextstream.html) or [arg](https://doc.qt.io/qt-6/qstring.html#arg)(), both of which support Unicode strings seamlessly and are type-safe.