### PR TITLE
Define g_efiUuid as constexpr

### DIFF
--- a/qefientrystaticlist.cpp
+++ b/qefientrystaticlist.cpp
@@ -13,7 +13,9 @@
 #define dec Qt::dec
 #endif
 
-QUuid g_efiUuid=QUuid("8be4df61-93ca-11d2-aa0d-00e098032b8c");
+// Defined in UEFI Spec as "EFI_GLOBAL_VARIABLE"
+constexpr QUuid g_efiUuid = QUuid(0x8be4df61, 0x93ca, 0x11d2, 0xaa, 0x0d, 0x00,
+                                  0xe0, 0x98, 0x03, 0x2b, 0x8c);
 
 QEFIEntryStaticList::QEFIEntryStaticList()
 {

--- a/qefientrystaticlist.h
+++ b/qefientrystaticlist.h
@@ -7,9 +7,6 @@
 
 #include <qefientry.h>
 
-extern QUuid g_efiUuid;
-
-
 class QEFIEntryStaticList
 {
 private:


### PR DESCRIPTION
- Reference: https://doc.qt.io/qt-6/quuid.html#QUuid-4

Use the constexpr constructor of `QUuid` to construct object `g_efiUuid` during compilation instead of runtime.